### PR TITLE
need to change self.async variable name to not clash with python 3.7 …

### DIFF
--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -102,7 +102,7 @@ class LibevConnection(BaseConnection):
                 self.ioloop = pyev.default_loop()
                 self.ioloop.update()
 
-        self.async = None
+        self._async = None
         self._on_signal_callback = on_signal_callback
         self._io_watcher = None
         self._active_timers = {}
@@ -143,8 +143,8 @@ class LibevConnection(BaseConnection):
 
             # NOTE: if someone knows why this async is needed here, please add
             # a comment in the code that explains it.
-            self.async = pyev.Async(self.ioloop, self._noop_callable)
-            self.async.start()
+            self._async = pyev.Async(self.ioloop, self._noop_callable)
+            self._async.start()
 
             if self._on_signal_callback:
                 global_sigterm_watcher.start()


### PR DESCRIPTION

## Proposed Changes

Rename the `LibevConnection` class's async member because it now (as of python >3.7) conflicts with the `async` language keyword.